### PR TITLE
Change required options to be non-option arguments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,8 @@ At least one of these arguments must be passed to GoPasswordCreator to specify w
 - **special**	Use special characters (like '-')
 - **own**	Takes a custom string that contains characters to use
 
+'all', 'alphanum', 'lower', 'upper', 'numbers', and 'special' may be followed by '=f' to nullify that character set.
+
 
 Options
 =======

--- a/README.markdown
+++ b/README.markdown
@@ -52,4 +52,4 @@ This generates passwords that could contain lower-case letters and the two chara
 This generates passwords that could contain any characters except for lower-case letters.
 
 	GoPasswordCreator -length 8 -count 5 -file passwords.txt all
-5 Passwords with 8 characters per password will be written into /home/d3xter/passwords.txt
+5 Passwords with 8 characters per password will be written into passwords.txt.

--- a/README.markdown
+++ b/README.markdown
@@ -2,45 +2,50 @@ GoPasswordCreator
 =================
 
 This program is used for generating passwords.
-The user can choose, which character-group will be used to generate the password.
-For example: lower case letters, numbers and so on.
-It is also possible for the user to define his/her own set of characters, which will be used to create the password.
+The user can choose which character-group will be used to generate the password.
+For example: lower case letters, numbers, and so on.
+It is also possible for the user to define his/her own set of characters which will be used to create the password.
 
 
 Compilation
 ===========
 
-The easiest way to compile the Password-Creator is, just to use the new "go" tool and run "go build" 
+The easiest way to compile the Password-Creator is just to use the new "go" tool and run "go build",
 and it will generate a binary called "GoPasswordCreator"
 
 
 Arguments
 =========
 
-There are several arguments, which can be passed to the Password-Creator:
+At least one of these arguments must be passed to GoPasswordCreator:
 
-- **--all**	When this Flag is set, lower/upper-case letters, numbers, special characters and by user defined characters are used to generate the password
-- **--lower**	Lower-Case Letters will be included
-- **--upper**	Upper-Case Letters will be included
-- **--numbers**	Numbers will be included
-- **--special**	Special Letters (like "-") will be included
-- **--own**	The User can pass a string to the Password-Creator and those characters in the string will be included
-- **--length** 	Specifies the length of the generated password. Default is set to 8
-- **--count**	User can specify with --count, how many passwords should be generated at the same. Default is set to 1
-- **--file**	If file is set, the passwords will be written into this file, rather than printed out on stdout
+- **all**	When this Flag is set, lower/upper-case letters, numbers, special characters and user defined characters are used to generate the password
+- **lower**	Lower-Case Letters will be included
+- **upper**	Upper-Case Letters will be included
+- **numbers**	Numbers will be included
+- **special**	Special Letters (like "-") will be included
+- **own**	The User can pass a string to GoPasswordCreator and those characters in the string will be included
+
+
+Options
+=======
+
+- **-length** 	Specifies the length of the generated password. Default is set to 8
+- **-count**	User can specify how many passwords should be generated at the same time. Default is set to 1
+- **-file**	If file is set, the passwords will be written into this file rather than printed out on stdout
 
 
 Examples
 ========
 
-	password_creator --lower --upper --numbers
-This Password could contain lower-case letters, upper-case letters and numbers
+	GoPasswordCreator lower upper numbers
+This Password could contain lower-case letters, upper-case letters, and numbers.
 
-	password_creator --lower --own "?="
-This password could contain lower-case letters and those two characters ("?" and "="), which the user has passed to the Password-Creator
+	GoPasswordCreator lower own="?="
+This password could contain lower-case letters and the two characters "?" and "=".
 
-	password_creator --lower=false --upper=true
-This password could contain upper-case letters. Lower-case letters will not be used to generate the password
+	GoPasswordCreator all lower=f
+This password could contain any characters except for lower-case letters.
 
-	password_creator --all --length 8 --count 5 --file /home/d3xter/passwords.txt
+	GoPasswordCreator -length 8 -count 5 -file /home/d3xter/passwords.txt all
 5 Passwords with 8 characters per password will be written into /home/d3xter/passwords.txt

--- a/README.markdown
+++ b/README.markdown
@@ -51,5 +51,5 @@ This generates passwords that could contain lower-case letters and the two chara
 	GoPasswordCreator all lower=f
 This generates passwords that could contain any characters except for lower-case letters.
 
-	GoPasswordCreator -length 8 -count 5 -file /home/d3xter/passwords.txt all
+	GoPasswordCreator -length 8 -count 5 -file passwords.txt all
 5 Passwords with 8 characters per password will be written into /home/d3xter/passwords.txt

--- a/README.markdown
+++ b/README.markdown
@@ -17,23 +17,23 @@ and it will generate a binary called "GoPasswordCreator"
 Arguments
 =========
 
-At least one of these arguments must be passed to GoPasswordCreator:
+At least one of these arguments must be passed to GoPasswordCreator to specify what characters may be used in the password:
 
-- **all**	When this Flag is set, lower/upper-case letters, numbers, special characters and user defined characters are used to generate the password
-- **alphanum**  When this flag is set, lower/upper-case letters, numbers, and user defined characters are used to generate the password
-- **lower**	Lower-Case Letters will be included
-- **upper**	Upper-Case Letters will be included
-- **numbers**	Numbers will be included
-- **special**	Special Letters (like "-") will be included
-- **own**	The User can pass a string to GoPasswordCreator and those characters in the string will be included
+- **all**	Equivalent to 'alphanum special'
+- **alphanum**  Equivalent to 'lower upper numbers'
+- **lower**	Use lower-case letters
+- **upper**	Use upper-case letters
+- **numbers**	Use digits
+- **special**	Use special characters (like '-')
+- **own**	Takes a custom string that contains characters to use
 
 
 Options
 =======
 
-- **-length** 	Specifies the length of the generated password. Default is set to 8
-- **-count**	User can specify how many passwords should be generated at the same time. Default is set to 1
-- **-file**	If file is set, the passwords will be written into this file rather than printed out on stdout
+- **-length** 	Specifies the length of the generated password. Default is 8.
+- **-count**	Specifies how many passwords to generate. Default is 1.
+- **-file**	Write passwords to the named file instead of standard output.
 
 
 Examples
@@ -43,7 +43,7 @@ Examples
 This generates passwords that could contain lower-case letters, upper-case letters, and numbers.
 
 	GoPasswordCreator alphanum
-This generates passwords that could contain lower-case letters, upper-case letters, and numbers.  This is  just a short hand for the previous command.
+This generates passwords that could contain lower-case letters, upper-case letters, and numbers.  This is just a short hand for the previous command.
 
 	GoPasswordCreator lower own="?="
 This generates passwords that could contain lower-case letters and the two characters "?" and "=".

--- a/README.markdown
+++ b/README.markdown
@@ -40,13 +40,16 @@ Examples
 ========
 
 	GoPasswordCreator lower upper numbers
-This Password could contain lower-case letters, upper-case letters, and numbers.
+This generates passwords that could contain lower-case letters, upper-case letters, and numbers.
+
+	GoPasswordCreator alphanum
+This generates passwords that could contain lower-case letters, upper-case letters, and numbers.  This is  just a short hand for the previous command.
 
 	GoPasswordCreator lower own="?="
-This password could contain lower-case letters and the two characters "?" and "=".
+This generates passwords that could contain lower-case letters and the two characters "?" and "=".
 
 	GoPasswordCreator all lower=f
-This password could contain any characters except for lower-case letters.
+This generates passwords that could contain any characters except for lower-case letters.
 
 	GoPasswordCreator -length 8 -count 5 -file /home/d3xter/passwords.txt all
 5 Passwords with 8 characters per password will be written into /home/d3xter/passwords.txt

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ Arguments
 At least one of these arguments must be passed to GoPasswordCreator:
 
 - **all**	When this Flag is set, lower/upper-case letters, numbers, special characters and user defined characters are used to generate the password
+- **alphanum**  When this flag is set, lower/upper-case letters, numbers, and user defined characters are used to generate the password
 - **lower**	Lower-Case Letters will be included
 - **upper**	Upper-Case Letters will be included
 - **numbers**	Numbers will be included

--- a/main.go
+++ b/main.go
@@ -55,6 +55,22 @@ Options:
 	flag.PrintDefaults()
 }
 
+// Sets a list of bool variables to the same value. If len(args) == 1, use true.
+// Otherwise, parse args[1] as a bool and use that.
+func setBool(args []string, vars ...*bool) {
+	on := true
+	if len(args) > 1 {
+		var err error
+		on, err = strconv.ParseBool(args[1])
+		if err != nil {
+			printError(err)
+		}
+	}
+	for _, bp := range vars {
+		*bp = on
+	}
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()
@@ -65,44 +81,31 @@ func main() {
 		parsed := strings.SplitN(arg, "=", 2)
 
 		// Group arguments by the data type of their value
-		if parsed[0] == "own" {
+		switch parsed[0] {
+		case "own":
 			// Need a string value
 			if len(parsed) == 2 {
 				usersCharacters = parsed[1]
 			} else {
 				printError(fmt.Errorf("'own' requires a '=' to specify characters"))
 			}
-		} else {
+
 			// All other arguments take boolean values
-			on := true
-			if len(parsed) == 2 {
-				var err error
-				on, err = strconv.ParseBool(parsed[1])
-				if err != nil {
-					printError(err)
-				}
-			}
-			switch parsed[0] {
-			case "all":
-				lowerCase = on
-				upperCase = on
-				numerals = on
-				specialCharacters = on
-			case "alphanum":
-				lowerCase = on
-				upperCase = on
-				numerals = on
-			case "lower":
-				lowerCase = on
-			case "upper":
-				upperCase = on
-			case "numbers":
-				numerals = on
-			case "special":
-				specialCharacters = on
-			default:
-				printError(fmt.Errorf("Invalid argument: %s", parsed[0]))
-			}
+		case "all":
+			setBool(parsed, &lowerCase, &upperCase, &numerals, &specialCharacters)
+		case "alphanum":
+			setBool(parsed, &lowerCase, &upperCase, &numerals)
+		case "lower":
+			setBool(parsed, &lowerCase)
+		case "upper":
+			setBool(parsed, &upperCase)
+		case "numbers":
+			setBool(parsed, &numerals)
+		case "special":
+			setBool(parsed, &specialCharacters)
+
+		default:
+			printError(fmt.Errorf("Invalid argument: %s", parsed[0]))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func usage() {
   numbers: Use digits
   special: Use special characters
   own: Characters defined by the user which will be also be used to generate the password
-'all', 'lower', 'upper', 'numbers', and 'special' may be followed by '=f' to nullify that character set.
+'all', 'alphanum', 'lower', 'upper', 'numbers', and 'special' may be followed by '=f' to nullify that character set.
 Options:
 `,
 		command, command)

--- a/main.go
+++ b/main.go
@@ -93,9 +93,9 @@ func main() {
 				numerals = on
 				specialCharacters = on
                         case "alphanum":
-				lowercase = on
-				uppercase = on
-				numerials = on
+				lowerCase = on
+				upperCase = on
+				numerals = on
 			case "lower":
 				lowerCase = on
 			case "upper":

--- a/main.go
+++ b/main.go
@@ -9,12 +9,11 @@ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 You should have received a copy of the GNU General Public License along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-
 package main
 
 import (
-	"fmt"
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -24,11 +23,11 @@ var (
 	passwordLength = flag.Int("length", 8, "Length of the generated Password")
 
 	// Variables that define what characters to use in the password
-	lowerCase bool
-	upperCase bool
-	numerals bool
+	lowerCase         bool
+	upperCase         bool
+	numerals          bool
 	specialCharacters bool
-	usersCharacters string
+	usersCharacters   string
 
 	//The user can determine how many passwords will be created
 	passwordCount = flag.Int("count", 1, "Determine how many passwords will be created")
@@ -38,10 +37,9 @@ var (
 	file = flag.String("file", "", "The File where the passwords should be written into")
 )
 
-
 func usage() {
 	command := os.Args[0]
-  fmt.Fprintf(os.Stderr,
+	fmt.Fprintf(os.Stderr,
 		`Usage: %s [all] [lower] [upper] [numbers] [special] [own=CHARACTERS]
 %s requires at least one of the following commands:
   all: Use lower/upper-case letters, numbers, special characters, and user defined characters to generate the password
@@ -55,9 +53,8 @@ func usage() {
 Options:
 `,
 		command, command)
-  flag.PrintDefaults()
+	flag.PrintDefaults()
 }
-
 
 func main() {
 	flag.Usage = usage
@@ -92,7 +89,7 @@ func main() {
 				upperCase = on
 				numerals = on
 				specialCharacters = on
-                        case "alphanum":
+			case "alphanum":
 				lowerCase = on
 				upperCase = on
 				numerals = on
@@ -130,12 +127,12 @@ func main() {
 	} else {
 		writeErr := creator.WritePasswords(*passwordLength, *passwordCount)
 
-		if writeErr != nil  {
+		if writeErr != nil {
 			printError(writeErr)
 		}
 	}
 }
 
 func printError(err error) {
-	fmt.Fprintln(os.Stderr, "Error: " + err.Error())
+	fmt.Fprintln(os.Stderr, "Error: "+err.Error())
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func usage() {
 		`Usage: %s [all] [lower] [upper] [numbers] [special] [own=CHARACTERS]
 %s requires at least one of the following commands:
   all: Use lower/upper-case letters, numbers, special characters, and user defined characters to generate the password
+  alphanum: Use lower/upper-case letters, numbers, and user defined characters to generate the password
   lower: Use lower-case letters
   upper: Use upper-case letters
   numbers: Use digits
@@ -91,6 +92,10 @@ func main() {
 				upperCase = on
 				numerals = on
 				specialCharacters = on
+                        case "alphanum":
+				lowercase = on
+				uppercase = on
+				numerials = on
 			case "lower":
 				lowerCase = on
 			case "upper":

--- a/main.go
+++ b/main.go
@@ -117,5 +117,5 @@ func main() {
 }
 
 func printError(err error) {
-	fmt.Println("Error: " + err.Error())
+	fmt.Fprintln(os.Stderr, "Error: " + err.Error())
 }

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 	}
 }
 
+// Prints err.Error() to Stdout.
 func printError(err error) {
 	fmt.Fprintln(os.Stderr, "Error: "+err.Error())
 }

--- a/main.go
+++ b/main.go
@@ -21,22 +21,22 @@ import (
 var (
 	passwordLength = flag.Int("length", 8, "Length of the generated Password")
 
-	//Define all available flags, which are used to specify, which characters to use to generate the password
+	//Define all available flags which are used to specify which characters to use to generate the password
 	lowerCase         = flag.Bool("lower", false, "Should LowerCase characters be included?")
 	upperCase         = flag.Bool("upper", false, "Should UpperCase characters be included?")
 	numerals          = flag.Bool("numbers", false, "Should the Numbers be included?")
 	specialCharacters = flag.Bool("special", false, "Should special characters be included?")
-	usersCharacters   = flag.String("own", "", "Characters defined by the user, which will be also be used to generate the password")
+	usersCharacters   = flag.String("own", "", "Characters defined by the user which will be also be used to generate the password")
 
-	//If --all Flag is set, then lower/upper-case letters, numbers and special characters and by user defined characters are used
-	allGroups = flag.Bool("all", false, "Use lower/upper-case letters, numbers, special characters and by user defined characters to generate the password")
+	//If --all Flag is set, then lower/upper-case letters, numbers, special characters, and user defined characters are used
+	allGroups = flag.Bool("all", false, "Use lower/upper-case letters, numbers, special characters, and user defined characters to generate the password")
 
-	//The user can determine, how many passwords will be created
-	passwordCount = flag.Int("count", 1, "Determine, how many passwords will be created")
+	//The user can determine how many passwords will be created
+	passwordCount = flag.Int("count", 1, "Determine how many passwords will be created")
 
-	//The user can define a file, where the passwords will be written into
-	//If file is omitted, then it will print the passwords on Stdout
-	file = flag.String("file", "", "The File, where the passwords should be written into")
+	//The user can define a file where the passwords will be written into.
+	//If file is omitted, then it will print the passwords on Stdout.
+	file = flag.String("file", "", "The File where the passwords should be written into")
 )
 
 

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func setBool(args []string, vars ...*bool) {
 		on, err = strconv.ParseBool(args[1])
 		if err != nil {
 			printError(err)
+			os.Exit(1)
 		}
 	}
 	for _, bp := range vars {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"flag"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -49,6 +50,7 @@ func usage() {
   numbers: Use digits
   special: Use special characters
   own: Characters defined by the user which will be also be used to generate the password
+'all', 'lower', 'upper', 'numbers', and 'special' may be followed by '=f' to nullify that character set.
 Options:
 `,
 		command, command)
@@ -65,28 +67,41 @@ func main() {
 		// Separate the subcommand from the value
 		parsed := strings.SplitN(arg, "=", 2)
 
-		switch parsed[0] {
-		case "all":
-			lowerCase = true
-			upperCase = true
-			numerals = true
-			specialCharacters = true
-		case "lower":
-			lowerCase = true
-		case "upper":
-			upperCase = true
-		case "numbers":
-			numerals = true
-		case "special":
-			specialCharacters = true
-		case "own":
+		// Group arguments by the data type of their value
+		if parsed[0] == "own" {
+			// Need a string value
 			if len(parsed) == 2 {
 				usersCharacters = parsed[1]
 			} else {
 				printError(fmt.Errorf("'own' requires a '=' to specify characters"))
 			}
-		default:
-			printError(fmt.Errorf("Invalid argument: %s", parsed[0]))
+		} else {
+			// All other arguments take boolean values
+			on := true
+			if len(parsed) == 2 {
+				var err error
+				on, err = strconv.ParseBool(parsed[1])
+				if err != nil {
+					printError(err)
+				}
+			}
+			switch parsed[0] {
+			case "all":
+				lowerCase = on
+				upperCase = on
+				numerals = on
+				specialCharacters = on
+			case "lower":
+				lowerCase = on
+			case "upper":
+				upperCase = on
+			case "numbers":
+				numerals = on
+			case "special":
+				specialCharacters = on
+			default:
+				printError(fmt.Errorf("Invalid argument: %s", parsed[0]))
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,27 +29,26 @@ var (
 	specialCharacters bool
 	usersCharacters   string
 
-	//The user can determine how many passwords will be created
-	passwordCount = flag.Int("count", 1, "Determine how many passwords will be created")
+	passwordCount = flag.Int("count", 1, "Determine how many passwords to create")
 
-	//The user can define a file where the passwords will be written into.
-	//If file is omitted, then it will print the passwords on Stdout.
-	file = flag.String("file", "", "The File where the passwords should be written into")
+	file = flag.String("file", "", "Write passwords to the named file instead of standard output")
 )
 
 func usage() {
 	command := os.Args[0]
 	fmt.Fprintf(os.Stderr,
-		`Usage: %s [all] [lower] [upper] [numbers] [special] [own=CHARACTERS]
-%s requires at least one of the following commands:
-  all: Use lower/upper-case letters, numbers, special characters, and user defined characters to generate the password
-  alphanum: Use lower/upper-case letters, numbers, and user defined characters to generate the password
+		`Usage: %s [all] [alphanum] [lower] [upper] [numbers] [special] [own=CHARACTERS]
+%s requires at least one of the following subcommands to specify what characters
+may be used in the password:
+  all: Equivalent to 'alphanum special'
+  alphanum: Equivalent to 'lower upper numbers'
   lower: Use lower-case letters
   upper: Use upper-case letters
   numbers: Use digits
   special: Use special characters
-  own: Characters defined by the user which will be also be used to generate the password
-'all', 'alphanum', 'lower', 'upper', 'numbers', and 'special' may be followed by '=f' to nullify that character set.
+  own: Specifies a custom set of characters to use
+'all', 'alphanum', 'lower', 'upper', 'numbers', and 'special' may be followed by
+'=f' to nullify that character set.
 Options:
 `,
 		command, command)

--- a/passwordcreator.go
+++ b/passwordcreator.go
@@ -9,20 +9,19 @@ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 You should have received a copy of the GNU General Public License along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-
 package main
 
 import (
-	"strings"
-	"crypto/rand"
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"os"
+	"strings"
 )
 
 type Creator struct {
 	characters string
-	file *os.File
+	file       *os.File
 }
 
 const (

--- a/passwordcreator_test.go
+++ b/passwordcreator_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"os"
+	"testing"
 )
 
 func TestDigitsCharset(t *testing.T) {
@@ -19,7 +19,7 @@ func TestSomeChars(t *testing.T) {
 
 	testCharacters := "abcdefghijklmnopqrstuvwxyz0123456789,.-_"
 
-	if err != nil || c.characters !=  testCharacters {
+	if err != nil || c.characters != testCharacters {
 		t.Errorf("Characters not distinct.\nExpected \"%s\", but got \"%s\"", testCharacters, c.characters)
 	}
 }


### PR DESCRIPTION
I've made a few changes that I hope you will like. The biggest change is treating some of the options as subcommands. At least one of 'all', 'upper', 'lower', 'numbers', 'special', and 'own' is required for GoPasswordCreator to do anything useful, so they should be treated as subcommands, not options.
