### PR TITLE
Make sure all characters in the pool are unique

### DIFF
--- a/passwordcreator.go
+++ b/passwordcreator.go
@@ -55,6 +55,18 @@ func NewCreator(file *os.File, lowerCase, upperCase, numerals, specialCharacters
 
 	characters += userCharacters
 
+	i := 0
+	seen := map[byte]struct{}{}
+	for i < len(characters) {
+		char := characters[i]
+		if _, ok := seen[char]; ok {
+			characters = characters[:i] + characters[i+1:]
+		} else {
+			i++
+			seen[char] = struct{}{}
+		}
+	}
+
 	if len(characters) <= 1 {
 		err = errors.New("Not enough Characters specified to generate passwords")
 		return nil, err

--- a/passwordcreator_test.go
+++ b/passwordcreator_test.go
@@ -23,3 +23,15 @@ func TestSomeChars(t *testing.T) {
 		t.Errorf("Characters not distinct.\nExpected \"%s\", but got \"%s\"", testCharacters, c.characters)
 	}
 }
+
+func TestUniqueChars(t *testing.T) {
+	expected := "ab"
+	if c, err := NewCreator(
+		os.Stdout, false, false, false, false, "aaabbb",
+	); c.characters != expected || err != nil {
+		t.Errorf(
+			"Characters not distinct.\nExpected \"%s\", but got \"%s\"",
+			expected, c.characters,
+		)
+	}
+}


### PR DESCRIPTION
Addresses issue #4.

This means every character chosen by the user has an equal chance of
being in the password.

I wonder if we should start using a byte slice for the character pool
for efficiency. Strings seem to work fine for now.